### PR TITLE
Change Export All to download ZIP instead of individual files

### DIFF
--- a/app.js
+++ b/app.js
@@ -2376,6 +2376,7 @@ async function exportAll() {
     }
 
     const originalIndex = state.selectedIndex;
+    const zip = new JSZip();
 
     for (let i = 0; i < state.screenshots.length; i++) {
         state.selectedIndex = i;
@@ -2383,16 +2384,23 @@ async function exportAll() {
 
         await new Promise(resolve => setTimeout(resolve, 100));
 
-        const link = document.createElement('a');
-        link.download = `screenshot-${i + 1}.png`;
-        link.href = canvas.toDataURL('image/png');
-        link.click();
+        // Get canvas data as base64, strip the data URL prefix
+        const dataUrl = canvas.toDataURL('image/png');
+        const base64Data = dataUrl.replace(/^data:image\/png;base64,/, '');
 
-        await new Promise(resolve => setTimeout(resolve, 300));
+        zip.file(`screenshot-${i + 1}.png`, base64Data, { base64: true });
     }
 
     state.selectedIndex = originalIndex;
     updateCanvas();
+
+    // Generate and download the ZIP file
+    const content = await zip.generateAsync({ type: 'blob' });
+    const link = document.createElement('a');
+    link.download = 'screenshots.zip';
+    link.href = URL.createObjectURL(content);
+    link.click();
+    URL.revokeObjectURL(link.href);
 }
 
 // Initialize the app

--- a/index.html
+++ b/index.html
@@ -17,6 +17,9 @@
 
     <link rel="stylesheet" href="styles.css">
 
+    <!-- JSZip for ZIP downloads -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"></script>
+
     <!-- Three.js for 3D mockups -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/loaders/GLTFLoader.js"></script>


### PR DESCRIPTION
- Add JSZip library via CDN for creating ZIP archives
- Modify exportAll() to bundle all screenshots into a single ZIP file
- Download as screenshots.zip instead of triggering multiple downloads