### PR TITLE
Include device resolution in exported screenshot ZIP filenames

### DIFF
--- a/app.js
+++ b/app.js
@@ -5502,7 +5502,7 @@ async function exportAllForLanguage(lang) {
     hideExportProgress();
 
     const link = document.createElement('a');
-    link.download = `screenshots-${lang}.zip`;
+    link.download = `screenshots_${state.outputDevice}_${lang}.zip`;
     link.href = URL.createObjectURL(content);
     link.click();
     URL.revokeObjectURL(link.href);
@@ -5576,7 +5576,7 @@ async function exportAllLanguages() {
     hideExportProgress();
 
     const link = document.createElement('a');
-    link.download = 'screenshots-all-languages.zip';
+    link.download = `screenshots_${state.outputDevice}_all-languages.zip`;
     link.href = URL.createObjectURL(content);
     link.click();
     URL.revokeObjectURL(link.href);


### PR DESCRIPTION
Hey, Great Tool BTW. 
So i was using it and I found that when I export screenshots the generated ZIP filename doesn’t include the selected device resolution, so I have to open multiple ZIPs to find the correct resolution for Play Store submission. With this change the device resolution is included in the ZIP name 
(before: 
> screenshots-en.zip

after: 
> screenshots_android-phone-hd_en.zip

so users can identify the correct screenshots without opening each archive.