### PR TITLE
add dandelion to apps using this project

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ Built something with this tool? Add your app to the list by submitting a pull re
 | AI Soccer Insights Football IQ | AI-powered football predictions and insights | [apple.com](https://apps.apple.com/us/app/ai-soccer-insights-football-iq/id6592649804) |
 | Navegatime | time tracking for workers and business functions | [play.google.com](https://play.google.com/store/apps/details?id=com.companyname.NavegaTime) |
 | Sommo | Your personal wine journey — scan labels, learn wine, and build your tasting journal | [sommo.app](https://sommo.app) |
+| Dandelion: Write and Let Go | An ephemeral journal for writing to let go, not save. | [apple.com](https://apps.apple.com/us/app/dandelion-write-and-let-go/id6757363901) |
 | *Your app here* | *Submit a PR to add your app* | *Your app link* |
 
 ## License


### PR DESCRIPTION
## Summary
This pull request adds **Dandelion: Write and Let Go** to the **Apps Using This Project** table in the repository README. Dandelion used this project to generate App Store screenshots, and this change records that usage in the project showcase list.

## User-facing impact
People evaluating this project can see an additional real-world production app that was built with the tool, which improves confidence and discoverability. The table now includes a direct App Store link so others can review the result in context.

## Root cause
The app had not yet been added to the community showcase table, so the README did not reflect all apps currently using the project.

## Fix
A single table row was inserted above the placeholder entry in `README.md` with:
- App: `Dandelion: Write and Let Go`
- Description: `An ephemeral journal for writing to let go, not save.`
- Link: `https://apps.apple.com/us/app/dandelion-write-and-let-go/id6757363901`

## Validation
Validation is documentation-only and was done by:
- Verifying Markdown table alignment and formatting consistency with existing rows.
- Confirming the App Store URL is reachable and correctly points to Dandelion.
