### PR TITLE
Input fields instead of text spans for range slider values

### DIFF
--- a/app.js
+++ b/app.js
@@ -2167,7 +2167,7 @@ function syncUIWithState() {
 
     // Gradient
     document.getElementById('gradient-angle').value = bg.gradient.angle;
-    document.getElementById('gradient-angle-value').textContent = formatValue(bg.gradient.angle) + '°';
+    document.getElementById('gradient-angle-value').value = formatValue(bg.gradient.angle);
     updateGradientStopsUI();
 
     // Solid color
@@ -4146,7 +4146,7 @@ function setupEventListeners() {
                 const angle = parseInt(angleMatch[1]);
                 setBackground('gradient.angle', angle);
                 document.getElementById('gradient-angle').value = angle;
-                document.getElementById('gradient-angle-value').textContent = formatValue(angle) + '°';
+                document.getElementById('gradient-angle-value').value = formatValue(angle);
             }
 
             const stops = [];
@@ -4165,7 +4165,15 @@ function setupEventListeners() {
     // Gradient angle
     document.getElementById('gradient-angle').addEventListener('input', (e) => {
         setBackground('gradient.angle', parseInt(e.target.value));
-        document.getElementById('gradient-angle-value').textContent = formatValue(e.target.value) + '°';
+        document.getElementById('gradient-angle-value').value = formatValue(e.target.value);
+        // Deselect preset when manually changing angle
+        document.querySelectorAll('.preset-swatch').forEach(s => s.classList.remove('selected'));
+        updateCanvas();
+    });
+    document.getElementById('gradient-angle-value').addEventListener('input', (e) => {
+        setBackground('gradient.angle', parseInt(e.target.value));
+        document.getElementById('gradient-angle-value').value = formatValue(e.target.value);
+        document.getElementById('gradient-angle').value = formatValue(e.target.value);
         // Deselect preset when manually changing angle
         document.querySelectorAll('.preset-swatch').forEach(s => s.classList.remove('selected'));
         updateCanvas();

--- a/app.js
+++ b/app.js
@@ -2177,50 +2177,50 @@ function syncUIWithState() {
     // Image background
     document.getElementById('bg-image-fit').value = bg.imageFit;
     document.getElementById('bg-blur').value = bg.imageBlur;
-    document.getElementById('bg-blur-value').textContent = formatValue(bg.imageBlur) + 'px';
+    document.getElementById('bg-blur-value').value = formatValue(bg.imageBlur)
     document.getElementById('bg-overlay-color').value = bg.overlayColor;
     document.getElementById('bg-overlay-hex').value = bg.overlayColor;
     document.getElementById('bg-overlay-opacity').value = bg.overlayOpacity;
-    document.getElementById('bg-overlay-opacity-value').textContent = formatValue(bg.overlayOpacity) + '%';
+    document.getElementById('bg-overlay-opacity-value').value = formatValue(bg.overlayOpacity)
 
     // Noise
     document.getElementById('noise-toggle').classList.toggle('active', bg.noise);
     document.getElementById('noise-intensity').value = bg.noiseIntensity;
-    document.getElementById('noise-intensity-value').textContent = formatValue(bg.noiseIntensity) + '%';
+    document.getElementById('noise-intensity-value').value = formatValue(bg.noiseIntensity)
 
     // Screenshot settings
     document.getElementById('screenshot-scale').value = ss.scale;
-    document.getElementById('screenshot-scale-value').textContent = formatValue(ss.scale) + '%';
+    document.getElementById('screenshot-scale-value').value = formatValue(ss.scale)
     document.getElementById('screenshot-y').value = ss.y;
-    document.getElementById('screenshot-y-value').textContent = formatValue(ss.y) + '%';
+    document.getElementById('screenshot-y-value').value = formatValue(ss.y)
     document.getElementById('screenshot-x').value = ss.x;
-    document.getElementById('screenshot-x-value').textContent = formatValue(ss.x) + '%';
+    document.getElementById('screenshot-x-value').value = formatValue(ss.x)
     document.getElementById('corner-radius').value = ss.cornerRadius;
-    document.getElementById('corner-radius-value').textContent = formatValue(ss.cornerRadius) + 'px';
+    document.getElementById('corner-radius-value').value = formatValue(ss.cornerRadius)
     document.getElementById('screenshot-rotation').value = ss.rotation;
-    document.getElementById('screenshot-rotation-value').textContent = formatValue(ss.rotation) + '°';
+    document.getElementById('screenshot-rotation-value').value = formatValue(ss.rotation)
 
     // Shadow
     document.getElementById('shadow-toggle').classList.toggle('active', ss.shadow.enabled);
     document.getElementById('shadow-color').value = ss.shadow.color;
     document.getElementById('shadow-color-hex').value = ss.shadow.color;
     document.getElementById('shadow-blur').value = ss.shadow.blur;
-    document.getElementById('shadow-blur-value').textContent = formatValue(ss.shadow.blur) + 'px';
+    document.getElementById('shadow-blur-value').value = formatValue(ss.shadow.blur)
     document.getElementById('shadow-opacity').value = ss.shadow.opacity;
-    document.getElementById('shadow-opacity-value').textContent = formatValue(ss.shadow.opacity) + '%';
+    document.getElementById('shadow-opacity-value').value = formatValue(ss.shadow.opacity)
     document.getElementById('shadow-x').value = ss.shadow.x;
-    document.getElementById('shadow-x-value').textContent = formatValue(ss.shadow.x) + 'px';
+    document.getElementById('shadow-x-value').value = formatValue(ss.shadow.x)
     document.getElementById('shadow-y').value = ss.shadow.y;
-    document.getElementById('shadow-y-value').textContent = formatValue(ss.shadow.y) + 'px';
+    document.getElementById('shadow-y-value').value = formatValue(ss.shadow.y)
 
     // Frame/Border
     document.getElementById('frame-toggle').classList.toggle('active', ss.frame.enabled);
     document.getElementById('frame-color').value = ss.frame.color;
     document.getElementById('frame-color-hex').value = ss.frame.color;
     document.getElementById('frame-width').value = ss.frame.width;
-    document.getElementById('frame-width-value').textContent = formatValue(ss.frame.width) + 'px';
+    document.getElementById('frame-width-value').value = formatValue(ss.frame.width)
     document.getElementById('frame-opacity').value = ss.frame.opacity;
-    document.getElementById('frame-opacity-value').textContent = formatValue(ss.frame.opacity) + '%';
+    document.getElementById('frame-opacity-value').value = formatValue(ss.frame.opacity)
 
     // Text
     const headlineLang = txt.currentHeadlineLang || 'en';
@@ -2246,16 +2246,16 @@ function syncUIWithState() {
         btn.classList.toggle('active', btn.dataset.position === layoutSettings.position);
     });
     document.getElementById('text-offset-y').value = layoutSettings.offsetY;
-    document.getElementById('text-offset-y-value').textContent = formatValue(layoutSettings.offsetY) + '%';
+    document.getElementById('text-offset-y-value').value = formatValue(layoutSettings.offsetY)
     document.getElementById('line-height').value = layoutSettings.lineHeight;
-    document.getElementById('line-height-value').textContent = formatValue(layoutSettings.lineHeight) + '%';
+    document.getElementById('line-height-value').value = formatValue(layoutSettings.lineHeight)
     const currentSubheadline = txt.subheadlines ? (txt.subheadlines[subheadlineLang] || '') : (txt.subheadline || '');
     document.getElementById('subheadline-text').value = currentSubheadline;
     document.getElementById('subheadline-font').value = txt.subheadlineFont || txt.headlineFont;
     document.getElementById('subheadline-size').value = subheadlineLayout.subheadlineSize;
     document.getElementById('subheadline-color').value = txt.subheadlineColor;
     document.getElementById('subheadline-opacity').value = txt.subheadlineOpacity;
-    document.getElementById('subheadline-opacity-value').textContent = formatValue(txt.subheadlineOpacity) + '%';
+    document.getElementById('subheadline-opacity-value').value = formatValue(txt.subheadlineOpacity)
     document.getElementById('subheadline-weight').value = txt.subheadlineWeight || '400';
     // Sync subheadline style buttons
     document.querySelectorAll('#subheadline-style button').forEach(btn => {
@@ -2290,11 +2290,11 @@ function syncUIWithState() {
     updateFrameColorSwatches(device3D, ss.frameColor);
     document.getElementById('rotation-3d-options').style.display = use3D ? 'block' : 'none';
     document.getElementById('rotation-3d-x').value = rotation3D.x;
-    document.getElementById('rotation-3d-x-value').textContent = formatValue(rotation3D.x) + '°';
+    document.getElementById('rotation-3d-x-value').value = formatValue(rotation3D.x)
     document.getElementById('rotation-3d-y').value = rotation3D.y;
-    document.getElementById('rotation-3d-y-value').textContent = formatValue(rotation3D.y) + '°';
+    document.getElementById('rotation-3d-y-value').value = formatValue(rotation3D.y)
     document.getElementById('rotation-3d-z').value = rotation3D.z;
-    document.getElementById('rotation-3d-z-value').textContent = formatValue(rotation3D.z) + '°';
+    document.getElementById('rotation-3d-z-value').value = formatValue(rotation3D.z)
 
     // Hide 2D-only settings in 3D mode, show 3D tip
     document.getElementById('2d-only-settings').style.display = use3D ? 'none' : 'block';
@@ -2428,15 +2428,15 @@ function updateElementProperties() {
 
     document.getElementById('element-layer').value = el.layer;
     document.getElementById('element-x').value = el.x;
-    document.getElementById('element-x-value').textContent = formatValue(el.x) + '%';
+    document.getElementById('element-x-value').value = formatValue(el.x)
     document.getElementById('element-y').value = el.y;
-    document.getElementById('element-y-value').textContent = formatValue(el.y) + '%';
+    document.getElementById('element-y-value').value = formatValue(el.y)
     document.getElementById('element-width').value = el.width;
-    document.getElementById('element-width-value').textContent = formatValue(el.width) + '%';
+    document.getElementById('element-width-value').value = formatValue(el.width)
     document.getElementById('element-rotation').value = el.rotation;
-    document.getElementById('element-rotation-value').textContent = formatValue(el.rotation) + '°';
+    document.getElementById('element-rotation-value').value = formatValue(el.rotation)
     document.getElementById('element-opacity').value = el.opacity;
-    document.getElementById('element-opacity-value').textContent = formatValue(el.opacity) + '%';
+    document.getElementById('element-opacity-value').value = formatValue(el.opacity)
 
     // Type-specific properties
     const textProps = document.getElementById('element-text-properties');
@@ -2462,14 +2462,14 @@ function updateElementProperties() {
             document.getElementById('element-frame-color').value = el.frameColor;
             document.getElementById('element-frame-color-hex').value = el.frameColor;
             document.getElementById('element-frame-scale').value = el.frameScale;
-            document.getElementById('element-frame-scale-value').textContent = formatValue(el.frameScale) + '%';
+            document.getElementById('element-frame-scale-value').value = formatValue(el.frameScale)
         }
     } else if (el.type === 'icon' && iconProps) {
         iconProps.style.display = '';
         document.getElementById('element-icon-color').value = el.iconColor || '#ffffff';
         document.getElementById('element-icon-color-hex').value = el.iconColor || '#ffffff';
         document.getElementById('element-icon-stroke-width').value = el.iconStrokeWidth || 2;
-        document.getElementById('element-icon-stroke-width-value').textContent = el.iconStrokeWidth || 2;
+        document.getElementById('element-icon-stroke-width-value').value = el.iconStrokeWidth || 2;
         // Shadow
         const shadow = el.iconShadow || { enabled: false, color: '#000000', blur: 20, opacity: 40, x: 0, y: 10 };
         const shadowToggle = document.getElementById('element-icon-shadow-toggle');
@@ -2481,13 +2481,13 @@ function updateElementProperties() {
         document.getElementById('element-icon-shadow-color').value = shadow.color;
         document.getElementById('element-icon-shadow-color-hex').value = shadow.color;
         document.getElementById('element-icon-shadow-blur').value = shadow.blur;
-        document.getElementById('element-icon-shadow-blur-value').textContent = shadow.blur + 'px';
+        document.getElementById('element-icon-shadow-blur-value').value = shadow.blur
         document.getElementById('element-icon-shadow-opacity').value = shadow.opacity;
-        document.getElementById('element-icon-shadow-opacity-value').textContent = shadow.opacity + '%';
+        document.getElementById('element-icon-shadow-opacity-value').value = shadow.opacity
         document.getElementById('element-icon-shadow-x').value = shadow.x;
-        document.getElementById('element-icon-shadow-x-value').textContent = shadow.x + 'px';
+        document.getElementById('element-icon-shadow-x-value').value = shadow.x
         document.getElementById('element-icon-shadow-y').value = shadow.y;
-        document.getElementById('element-icon-shadow-y-value').textContent = shadow.y + 'px';
+        document.getElementById('element-icon-shadow-y-value').value = shadow.y
     }
 }
 
@@ -3158,27 +3158,27 @@ function updatePopoutProperties() {
 
     // Crop region
     document.getElementById('popout-crop-x').value = p.cropX;
-    document.getElementById('popout-crop-x-value').textContent = formatValue(p.cropX) + '%';
+    document.getElementById('popout-crop-x-value').value = formatValue(p.cropX)
     document.getElementById('popout-crop-y').value = p.cropY;
-    document.getElementById('popout-crop-y-value').textContent = formatValue(p.cropY) + '%';
+    document.getElementById('popout-crop-y-value').value = formatValue(p.cropY)
     document.getElementById('popout-crop-width').value = p.cropWidth;
-    document.getElementById('popout-crop-width-value').textContent = formatValue(p.cropWidth) + '%';
+    document.getElementById('popout-crop-width-value').value = formatValue(p.cropWidth)
     document.getElementById('popout-crop-height').value = p.cropHeight;
-    document.getElementById('popout-crop-height-value').textContent = formatValue(p.cropHeight) + '%';
+    document.getElementById('popout-crop-height-value').value = formatValue(p.cropHeight)
 
     // Display
     document.getElementById('popout-x').value = p.x;
-    document.getElementById('popout-x-value').textContent = formatValue(p.x) + '%';
+    document.getElementById('popout-x-value').value = formatValue(p.x)
     document.getElementById('popout-y').value = p.y;
-    document.getElementById('popout-y-value').textContent = formatValue(p.y) + '%';
+    document.getElementById('popout-y-value').value = formatValue(p.y)
     document.getElementById('popout-width').value = p.width;
-    document.getElementById('popout-width-value').textContent = formatValue(p.width) + '%';
+    document.getElementById('popout-width-value').value = formatValue(p.width)
     document.getElementById('popout-rotation').value = p.rotation;
-    document.getElementById('popout-rotation-value').textContent = formatValue(p.rotation) + '°';
+    document.getElementById('popout-rotation-value').value = formatValue(p.rotation)
     document.getElementById('popout-opacity').value = p.opacity;
-    document.getElementById('popout-opacity-value').textContent = formatValue(p.opacity) + '%';
+    document.getElementById('popout-opacity-value').value = formatValue(p.opacity)
     document.getElementById('popout-corner-radius').value = p.cornerRadius;
-    document.getElementById('popout-corner-radius-value').textContent = formatValue(p.cornerRadius) + 'px';
+    document.getElementById('popout-corner-radius-value').value = formatValue(p.cornerRadius)
 
     // Shadow
     const shadow = p.shadow || { enabled: false, color: '#000000', blur: 30, opacity: 40, x: 0, y: 15 };
@@ -3189,13 +3189,13 @@ function updatePopoutProperties() {
     document.getElementById('popout-shadow-color').value = shadow.color;
     document.getElementById('popout-shadow-color-hex').value = shadow.color;
     document.getElementById('popout-shadow-blur').value = shadow.blur;
-    document.getElementById('popout-shadow-blur-value').textContent = formatValue(shadow.blur) + 'px';
+    document.getElementById('popout-shadow-blur-value').value = formatValue(shadow.blur)
     document.getElementById('popout-shadow-opacity').value = shadow.opacity;
-    document.getElementById('popout-shadow-opacity-value').textContent = formatValue(shadow.opacity) + '%';
+    document.getElementById('popout-shadow-opacity-value').value = formatValue(shadow.opacity)
     document.getElementById('popout-shadow-x').value = shadow.x;
-    document.getElementById('popout-shadow-x-value').textContent = formatValue(shadow.x) + 'px';
+    document.getElementById('popout-shadow-x-value').value = formatValue(shadow.x)
     document.getElementById('popout-shadow-y').value = shadow.y;
-    document.getElementById('popout-shadow-y-value').textContent = formatValue(shadow.y) + 'px';
+    document.getElementById('popout-shadow-y-value').textvalueContent = formatValue(shadow.y)
 
     // Border
     const border = p.border || { enabled: false, color: '#ffffff', width: 3, opacity: 100 };
@@ -3206,9 +3206,9 @@ function updatePopoutProperties() {
     document.getElementById('popout-border-color').value = border.color;
     document.getElementById('popout-border-color-hex').value = border.color;
     document.getElementById('popout-border-width').value = border.width;
-    document.getElementById('popout-border-width-value').textContent = formatValue(border.width) + 'px';
+    document.getElementById('popout-border-width-value').value = formatValue(border.width)
     document.getElementById('popout-border-opacity').value = border.opacity;
-    document.getElementById('popout-border-opacity-value').textContent = formatValue(border.opacity) + '%';
+    document.getElementById('popout-border-opacity-value').value = formatValue(border.opacity)
 
     // Update crop preview
     updateCropPreview();
@@ -4235,7 +4235,12 @@ function setupEventListeners() {
 
     document.getElementById('bg-blur').addEventListener('input', (e) => {
         setBackground('imageBlur', parseInt(e.target.value));
-        document.getElementById('bg-blur-value').textContent = formatValue(e.target.value) + 'px';
+        document.getElementById('bg-blur-value').value = formatValue(e.target.value)
+        updateCanvas();
+    });
+    document.getElementById('bg-blur-value').addEventListener('input', (e) => {
+        setBackground('imageBlur', parseInt(e.target.value));
+        document.getElementById('bg-blur').value = formatValue(e.target.value)
         updateCanvas();
     });
 
@@ -4247,7 +4252,12 @@ function setupEventListeners() {
 
     document.getElementById('bg-overlay-opacity').addEventListener('input', (e) => {
         setBackground('overlayOpacity', parseInt(e.target.value));
-        document.getElementById('bg-overlay-opacity-value').textContent = formatValue(e.target.value) + '%';
+        document.getElementById('bg-overlay-opacity-value').value = formatValue(e.target.value)
+        updateCanvas();
+    });
+    document.getElementById('bg-overlay-opacity-value').addEventListener('input', (e) => {
+        setBackground('overlayOpacity', parseInt(e.target.value));
+        document.getElementById('bg-overlay-opacity').value = formatValue(e.target.value)
         updateCanvas();
     });
 
@@ -4269,38 +4279,68 @@ function setupEventListeners() {
 
     document.getElementById('noise-intensity').addEventListener('input', (e) => {
         setBackground('noiseIntensity', parseInt(e.target.value));
-        document.getElementById('noise-intensity-value').textContent = formatValue(e.target.value) + '%';
+        document.getElementById('noise-intensity-value').value = formatValue(e.target.value)
+        updateCanvas();
+    });
+    document.getElementById('noise-intensity-value').addEventListener('input', (e) => {
+        setBackground('noiseIntensity', parseInt(e.target.value));
+        document.getElementById('noise-intensity').value = formatValue(e.target.value)
         updateCanvas();
     });
 
     // Screenshot settings
     document.getElementById('screenshot-scale').addEventListener('input', (e) => {
         setScreenshotSetting('scale', parseInt(e.target.value));
-        document.getElementById('screenshot-scale-value').textContent = formatValue(e.target.value) + '%';
+        document.getElementById('screenshot-scale-value').value = formatValue(e.target.value)
+        updateCanvas();
+    });
+    document.getElementById('screenshot-scale-value').addEventListener('input', (e) => {
+        setScreenshotSetting('scale', parseInt(e.target.value));
+        document.getElementById('screenshot-scale').value = formatValue(e.target.value)
         updateCanvas();
     });
 
     document.getElementById('screenshot-y').addEventListener('input', (e) => {
         setScreenshotSetting('y', parseInt(e.target.value));
-        document.getElementById('screenshot-y-value').textContent = formatValue(e.target.value) + '%';
+        document.getElementById('screenshot-y-value').value = formatValue(e.target.value)
+        updateCanvas();
+    });
+    document.getElementById('screenshot-y-value').addEventListener('input', (e) => {
+        setScreenshotSetting('y', parseInt(e.target.value));
+        document.getElementById('screenshot-y').value = formatValue(e.target.value)
         updateCanvas();
     });
 
     document.getElementById('screenshot-x').addEventListener('input', (e) => {
         setScreenshotSetting('x', parseInt(e.target.value));
-        document.getElementById('screenshot-x-value').textContent = formatValue(e.target.value) + '%';
+        document.getElementById('screenshot-x-value').value = formatValue(e.target.value)
+        updateCanvas();
+    });
+    document.getElementById('screenshot-x-value').addEventListener('input', (e) => {
+        setScreenshotSetting('x', parseInt(e.target.value));
+        document.getElementById('screenshot-x').value = formatValue(e.target.value)
         updateCanvas();
     });
 
     document.getElementById('corner-radius').addEventListener('input', (e) => {
         setScreenshotSetting('cornerRadius', parseInt(e.target.value));
-        document.getElementById('corner-radius-value').textContent = formatValue(e.target.value) + 'px';
+        document.getElementById('corner-radius-value').value = formatValue(e.target.value)
+        updateCanvas();
+    });
+    document.getElementById('corner-radius-value').addEventListener('input', (e) => {
+        setScreenshotSetting('cornerRadius', parseInt(e.target.value));
+        document.getElementById('corner-radius').value = formatValue(e.target.value)
         updateCanvas();
     });
 
     document.getElementById('screenshot-rotation').addEventListener('input', (e) => {
         setScreenshotSetting('rotation', parseInt(e.target.value));
-        document.getElementById('screenshot-rotation-value').textContent = formatValue(e.target.value) + '°';
+        document.getElementById('screenshot-rotation-value').value = formatValue(e.target.value)
+        updateCanvas();
+    });
+    document.getElementById('screenshot-rotation-value').addEventListener('input', (e) => {
+        setScreenshotSetting('rotation', parseInt(e.target.value));
+        document.getElementById('screenshot-rotation').value = formatValue(e.target.value)
         updateCanvas();
     });
 
@@ -4328,25 +4368,45 @@ function setupEventListeners() {
 
     document.getElementById('shadow-blur').addEventListener('input', (e) => {
         setScreenshotSetting('shadow.blur', parseInt(e.target.value));
-        document.getElementById('shadow-blur-value').textContent = formatValue(e.target.value) + 'px';
+        document.getElementById('shadow-blur-value').value = formatValue(e.target.value)
+        updateCanvas();
+    });
+    document.getElementById('shadow-blur-value').addEventListener('input', (e) => {
+        setScreenshotSetting('shadow.blur', parseInt(e.target.value));
+        document.getElementById('shadow-blur').value = formatValue(e.target.value)
         updateCanvas();
     });
 
     document.getElementById('shadow-opacity').addEventListener('input', (e) => {
         setScreenshotSetting('shadow.opacity', parseInt(e.target.value));
-        document.getElementById('shadow-opacity-value').textContent = formatValue(e.target.value) + '%';
+        document.getElementById('shadow-opacity-value').value = formatValue(e.target.value)
+        updateCanvas();
+    });
+    document.getElementById('shadow-opacity-value').addEventListener('input', (e) => {
+        setScreenshotSetting('shadow.opacity', parseInt(e.target.value));
+        document.getElementById('shadow-opacity').value = formatValue(e.target.value)
         updateCanvas();
     });
 
     document.getElementById('shadow-x').addEventListener('input', (e) => {
         setScreenshotSetting('shadow.x', parseInt(e.target.value));
-        document.getElementById('shadow-x-value').textContent = formatValue(e.target.value) + 'px';
+        document.getElementById('shadow-x-value').value = formatValue(e.target.value)
+        updateCanvas();
+    });
+    document.getElementById('shadow-x-value').addEventListener('input', (e) => {
+        setScreenshotSetting('shadow.x', parseInt(e.target.value));
+        document.getElementById('shadow-x').value = formatValue(e.target.value)
         updateCanvas();
     });
 
     document.getElementById('shadow-y').addEventListener('input', (e) => {
         setScreenshotSetting('shadow.y', parseInt(e.target.value));
-        document.getElementById('shadow-y-value').textContent = formatValue(e.target.value) + 'px';
+        document.getElementById('shadow-y-value').value = formatValue(e.target.value)
+        updateCanvas();
+    });
+    document.getElementById('shadow-y-value').addEventListener('input', (e) => {
+        setScreenshotSetting('shadow.y', parseInt(e.target.value));
+        document.getElementById('shadow-y').value = formatValue(e.target.value)
         updateCanvas();
     });
 
@@ -4382,13 +4442,23 @@ function setupEventListeners() {
 
     document.getElementById('frame-width').addEventListener('input', (e) => {
         setScreenshotSetting('frame.width', parseInt(e.target.value));
-        document.getElementById('frame-width-value').textContent = formatValue(e.target.value) + 'px';
+        document.getElementById('frame-width-value').value = formatValue(e.target.value)
+        updateCanvas();
+    });
+    document.getElementById('frame-width-value').addEventListener('input', (e) => {
+        setScreenshotSetting('frame.width', parseInt(e.target.value));
+        document.getElementById('frame-width').value = formatValue(e.target.value)
         updateCanvas();
     });
 
     document.getElementById('frame-opacity').addEventListener('input', (e) => {
         setScreenshotSetting('frame.opacity', parseInt(e.target.value));
-        document.getElementById('frame-opacity-value').textContent = formatValue(e.target.value) + '%';
+        document.getElementById('frame-opacity-value').value = formatValue(e.target.value)
+        updateCanvas();
+    });
+    document.getElementById('frame-opacity-value').addEventListener('input', (e) => {
+        setScreenshotSetting('frame.opacity', parseInt(e.target.value));
+        document.getElementById('frame-opacity').value = formatValue(e.target.value)
         updateCanvas();
     });
 
@@ -4498,13 +4568,23 @@ function setupEventListeners() {
 
     document.getElementById('text-offset-y').addEventListener('input', (e) => {
         setTextLanguageValue('offsetY', parseInt(e.target.value));
-        document.getElementById('text-offset-y-value').textContent = formatValue(e.target.value) + '%';
+        document.getElementById('text-offset-y-value').value = formatValue(e.target.value)
+        updateCanvas();
+    });
+    document.getElementById('text-offset-y-value').addEventListener('input', (e) => {
+        setTextLanguageValue('offsetY', parseInt(e.target.value));
+        document.getElementById('text-offset-y').value = formatValue(e.target.value)
         updateCanvas();
     });
 
     document.getElementById('line-height').addEventListener('input', (e) => {
         setTextLanguageValue('lineHeight', parseInt(e.target.value));
-        document.getElementById('line-height-value').textContent = formatValue(e.target.value) + '%';
+        document.getElementById('line-height-value').value = formatValue(e.target.value)
+        updateCanvas();
+    });
+    document.getElementById('line-height-value').addEventListener('input', (e) => {
+        setTextLanguageValue('lineHeight', parseInt(e.target.value));
+        document.getElementById('line-height').value = formatValue(e.target.value)
         updateCanvas();
     });
 
@@ -4530,7 +4610,13 @@ function setupEventListeners() {
     document.getElementById('subheadline-opacity').addEventListener('input', (e) => {
         const value = parseInt(e.target.value) || 70;
         setTextValue('subheadlineOpacity', value);
-        document.getElementById('subheadline-opacity-value').textContent = formatValue(value) + '%';
+        document.getElementById('subheadline-opacity-value').value = formatValue(value)
+        updateCanvas();
+    });
+    document.getElementById('subheadline-opacity-value').addEventListener('input', (e) => {
+        const value = parseInt(e.target.value) || 70;
+        setTextValue('subheadlineOpacity', value);
+        document.getElementById('subheadline-opacity').value = formatValue(value)
         updateCanvas();
     });
 
@@ -4627,7 +4713,17 @@ function setupEventListeners() {
         const ss = getScreenshotSettings();
         if (!ss.rotation3D) ss.rotation3D = { x: 0, y: 0, z: 0 };
         ss.rotation3D.x = parseInt(e.target.value);
-        document.getElementById('rotation-3d-x-value').textContent = formatValue(e.target.value) + '°';
+        document.getElementById('rotation-3d-x-value').value = formatValue(e.target.value)
+        if (typeof setThreeJSRotation === 'function') {
+            setThreeJSRotation(ss.rotation3D.x, ss.rotation3D.y, ss.rotation3D.z);
+        }
+        updateCanvas(); // Keep export canvas in sync
+    });
+    document.getElementById('rotation-3d-x-value').addEventListener('input', (e) => {
+        const ss = getScreenshotSettings();
+        if (!ss.rotation3D) ss.rotation3D = { x: 0, y: 0, z: 0 };
+        ss.rotation3D.x = parseInt(e.target.value);
+        document.getElementById('rotation-3d-x').value = formatValue(e.target.value)
         if (typeof setThreeJSRotation === 'function') {
             setThreeJSRotation(ss.rotation3D.x, ss.rotation3D.y, ss.rotation3D.z);
         }
@@ -4638,7 +4734,17 @@ function setupEventListeners() {
         const ss = getScreenshotSettings();
         if (!ss.rotation3D) ss.rotation3D = { x: 0, y: 0, z: 0 };
         ss.rotation3D.y = parseInt(e.target.value);
-        document.getElementById('rotation-3d-y-value').textContent = formatValue(e.target.value) + '°';
+        document.getElementById('rotation-3d-y-value').value = formatValue(e.target.value)
+        if (typeof setThreeJSRotation === 'function') {
+            setThreeJSRotation(ss.rotation3D.x, ss.rotation3D.y, ss.rotation3D.z);
+        }
+        updateCanvas(); // Keep export canvas in sync
+    });
+    document.getElementById('rotation-3d-y-value').addEventListener('input', (e) => {
+        const ss = getScreenshotSettings();
+        if (!ss.rotation3D) ss.rotation3D = { x: 0, y: 0, z: 0 };
+        ss.rotation3D.y = parseInt(e.target.value);
+        document.getElementById('rotation-3d-y').value = formatValue(e.target.value)
         if (typeof setThreeJSRotation === 'function') {
             setThreeJSRotation(ss.rotation3D.x, ss.rotation3D.y, ss.rotation3D.z);
         }
@@ -4649,7 +4755,17 @@ function setupEventListeners() {
         const ss = getScreenshotSettings();
         if (!ss.rotation3D) ss.rotation3D = { x: 0, y: 0, z: 0 };
         ss.rotation3D.z = parseInt(e.target.value);
-        document.getElementById('rotation-3d-z-value').textContent = formatValue(e.target.value) + '°';
+        document.getElementById('rotation-3d-z-value').value = formatValue(e.target.value)
+        if (typeof setThreeJSRotation === 'function') {
+            setThreeJSRotation(ss.rotation3D.x, ss.rotation3D.y, ss.rotation3D.z);
+        }
+        updateCanvas(); // Keep export canvas in sync
+    });
+    document.getElementById('rotation-3d-z-value').addEventListener('input', (e) => {
+        const ss = getScreenshotSettings();
+        if (!ss.rotation3D) ss.rotation3D = { x: 0, y: 0, z: 0 };
+        ss.rotation3D.z = parseInt(e.target.value);
+        document.getElementById('rotation-3d-z').value = formatValue(e.target.value)
         if (typeof setThreeJSRotation === 'function') {
             setThreeJSRotation(ss.rotation3D.x, ss.rotation3D.y, ss.rotation3D.z);
         }
@@ -5902,15 +6018,15 @@ function updateTextUI(text) {
         btn.classList.toggle('active', btn.dataset.position === layoutSettings.position);
     });
     document.getElementById('text-offset-y').value = layoutSettings.offsetY;
-    document.getElementById('text-offset-y-value').textContent = formatValue(layoutSettings.offsetY) + '%';
+    document.getElementById('text-offset-y-value').value = formatValue(layoutSettings.offsetY)
     document.getElementById('line-height').value = layoutSettings.lineHeight;
-    document.getElementById('line-height-value').textContent = formatValue(layoutSettings.lineHeight) + '%';
+    document.getElementById('line-height-value').value = formatValue(layoutSettings.lineHeight)
     document.getElementById('subheadline-text').value = subheadlineText;
     document.getElementById('subheadline-font').value = text.subheadlineFont || text.headlineFont;
     document.getElementById('subheadline-size').value = subheadlineLayout.subheadlineSize;
     document.getElementById('subheadline-color').value = text.subheadlineColor;
     document.getElementById('subheadline-opacity').value = text.subheadlineOpacity;
-    document.getElementById('subheadline-opacity-value').textContent = formatValue(text.subheadlineOpacity) + '%';
+    document.getElementById('subheadline-opacity-value').value = formatValue(text.subheadlineOpacity)
     document.getElementById('subheadline-weight').value = text.subheadlineWeight || '400';
     // Sync subheadline style buttons
     document.querySelectorAll('#subheadline-style button').forEach(btn => {
@@ -5943,13 +6059,13 @@ function applyPositionPreset(preset) {
 
     // Update UI controls
     document.getElementById('screenshot-scale').value = p.scale;
-    document.getElementById('screenshot-scale-value').textContent = formatValue(p.scale) + '%';
+    document.getElementById('screenshot-scale-value').value = formatValue(p.scale)
     document.getElementById('screenshot-x').value = p.x;
-    document.getElementById('screenshot-x-value').textContent = formatValue(p.x) + '%';
+    document.getElementById('screenshot-x-value').value = formatValue(p.x)
     document.getElementById('screenshot-y').value = p.y;
-    document.getElementById('screenshot-y-value').textContent = formatValue(p.y) + '%';
+    document.getElementById('screenshot-y-value').value = formatValue(p.y)
     document.getElementById('screenshot-rotation').value = p.rotation;
-    document.getElementById('screenshot-rotation-value').textContent = formatValue(p.rotation) + '°';
+    document.getElementById('screenshot-rotation-value').texvaluetContent = formatValue(p.rotation)
 
     updateCanvas();
 }

--- a/app.js
+++ b/app.js
@@ -536,6 +536,9 @@ function setupSliderResetButtons() {
 
 // Format number to at most 1 decimal place
 function formatValue(num) {
+    if(isNaN(num)){
+        return ""
+    }
     const rounded = Math.round(num * 10) / 10;
     return Number.isInteger(rounded) ? rounded.toString() : rounded.toFixed(1);
 }
@@ -2594,7 +2597,16 @@ function setupElementEventListeners() {
             const el = getSelectedElement();
             if (!el || el.type !== 'icon' || !el.iconShadow) return;
             el.iconShadow[prop] = parseFloat(input.value);
-            if (valEl) valEl.textContent = input.value + suffix;
+            if (valEl) valEl.value = input.value
+            if (input) input.value = input.value
+            updateCanvas();
+        });
+        valEl.addEventListener('input', () => {
+            const el = getSelectedElement();
+            if (!el || el.type !== 'icon' || !el.iconShadow) return;
+            el.iconShadow[prop] = parseFloat(valEl.value);
+            if (valEl) valEl.value = valEl.value
+            if (input) input.value = valEl.value
             updateCanvas();
         });
     };
@@ -2634,12 +2646,26 @@ function setupElementEventListeners() {
         const input = document.getElementById(id);
         const valueEl = document.getElementById(id + '-value');
         if (!input) return;
+        if(!valueEl) return
         input.addEventListener('input', () => {
             const val = parser ? parser(input.value) : parseFloat(input.value);
-            if (valueEl) valueEl.textContent = formatValue(val) + suffix;
+            if (valueEl) valueEl.value = formatValue(val)
+            if (input) input.value = formatValue(val)
+            if (selectedElementId) setElementProperty(selectedElementId, prop, val);
+        });
+        valueEl.addEventListener('input', () => {
+            const val = parser ? parser(valueEl.value) : parseFloat(valueEl.value);
+            if (valueEl) valueEl.value = formatValue(val)
+            if (input) input.value = formatValue(val)
             if (selectedElementId) setElementProperty(selectedElementId, prop, val);
         });
     };
+
+    /*document.getElementById('element-x-value').addEventListener('input', (e) => {
+        setScreenshotSetting('element-x', parseInt(e.target.value));
+        document.getElementById('element-x').value = formatValue(e.target.value)
+        updateCanvas();
+    });*/
 
     bindSlider('element-x', 'x', '%');
     bindSlider('element-y', 'y', '%');
@@ -3476,7 +3502,15 @@ function setupPopoutEventListeners() {
         if (!input) return;
         input.addEventListener('input', () => {
             const val = parseFloat(input.value);
-            if (valueEl) valueEl.textContent = formatValue(val) + suffix;
+            if (valueEl) valueEl.value = formatValue(val)
+            if (input) input.value = formatValue(val)
+            if (selectedPopoutId) setPopoutProperty(selectedPopoutId, key, val);
+            if (key.startsWith('crop')) updateCropPreview();
+        });
+        valueEl.addEventListener('input', () => {
+            const val = parseFloat(valueEl.value);
+            if (valueEl) valueEl.value = formatValue(val)
+            if (input) input.value = formatValue(val)
             if (selectedPopoutId) setPopoutProperty(selectedPopoutId, key, val);
             if (key.startsWith('crop')) updateCropPreview();
         });
@@ -3514,7 +3548,16 @@ function setupPopoutEventListeners() {
             const p = getSelectedPopout();
             if (!p) return;
             p.shadow[prop] = parseFloat(input.value);
-            if (valEl) valEl.textContent = formatValue(parseFloat(input.value)) + suffix;
+            if (valEl) valEl.value = formatValue(parseFloat(input.value))
+            if (input) input.value = formatValue(parseFloat(input.value))
+            updateCanvas();
+        });
+        valEl.addEventListener('input', () => {
+            const p = getSelectedPopout();
+            if (!p) return;
+            p.shadow[prop] = parseFloat(valEl.value);
+            if (valEl) valEl.value = formatValue(parseFloat(valEl.value))
+            if (input) input.value = formatValue(parseFloat(valEl.value))
             updateCanvas();
         });
     };
@@ -3562,7 +3605,16 @@ function setupPopoutEventListeners() {
             const p = getSelectedPopout();
             if (!p) return;
             p.border[prop] = parseFloat(input.value);
-            if (valEl) valEl.textContent = formatValue(parseFloat(input.value)) + suffix;
+            if (valEl) valEl.value = formatValue(parseFloat(input.value))
+            if (input) input.value = formatValue(parseFloat(input.value))
+            updateCanvas();
+        });
+        valEl.addEventListener('input', () => {
+            const p = getSelectedPopout();
+            if (!p) return;
+            p.border[prop] = parseFloat(valEl.value);
+            if (valEl) valEl.value = formatValue(parseFloat(valEl.value))
+            if (input) input.value = formatValue(parseFloat(valEl.value))
             updateCanvas();
         });
     };

--- a/index.html
+++ b/index.html
@@ -422,7 +422,10 @@
                         <label class="control-label">Gradient Direction</label>
                         <div class="control-row">
                             <input type="range" id="gradient-angle" min="0" max="360" value="135">
-                            <div class="trailing-input-symbol-wrapper"><input type="text" class="range-value" id="gradient-angle-value"></input><span class="trailing-input-symbol">°</span></div>
+                            <div class="trailing-input-symbol-wrapper">
+                                <input type="text" class="range-value" id="gradient-angle-value" min="0" max="360" value="135"></input>
+                                <span class="trailing-input-symbol">°</span>
+                            </div>
 
                         </div>
                     </div>
@@ -478,7 +481,10 @@
                         <label class="control-label">Blur</label>
                         <div class="control-row">
                             <input type="range" id="bg-blur" min="0" max="50" value="0">
-                            <span class="range-value" id="bg-blur-value">0px</span>
+                            <div class="trailing-input-symbol-wrapper">
+                                <input type="text" class="range-value" id="bg-blur-value" min="0" max="50" value="0"></input>
+                                <span class="trailing-input-symbol">px</span>
+                            </div>
                         </div>
                     </div>
                     <div class="control-group">
@@ -492,7 +498,10 @@
                         <label class="control-label">Overlay Opacity</label>
                         <div class="control-row">
                             <input type="range" id="bg-overlay-opacity" min="0" max="100" value="0">
-                            <span class="range-value" id="bg-overlay-opacity-value">0%</span>
+                            <div class="trailing-input-symbol-wrapper">
+                                <input type="text" class="range-value" id="bg-overlay-opacity-value" min="0" max="100" value="0"></input>
+                                <span class="trailing-input-symbol">%</span>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -515,7 +524,10 @@
                         <label class="control-label">Noise Intensity</label>
                         <div class="control-row">
                             <input type="range" id="noise-intensity" min="0" max="100" value="10">
-                            <span class="range-value" id="noise-intensity-value">10%</span>
+                            <div class="trailing-input-symbol-wrapper">
+                                <input type="text" class="range-value" id="noise-intensity-value" min="0" max="100" value="10"></input>
+                                <span class="trailing-input-symbol">%</span>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -543,21 +555,30 @@
                         <label class="control-label">Rotation X (Tilt)</label>
                         <div class="control-row">
                             <input type="range" id="rotation-3d-x" min="-45" max="45" value="0">
-                            <span class="range-value" id="rotation-3d-x-value">0°</span>
+                            <div class="trailing-input-symbol-wrapper">
+                                <input type="text" class="range-value" id="rotation-3d-x-value" min="-45" max="45" value="0"></input>
+                                <span class="trailing-input-symbol">°</span>
+                            </div>
                         </div>
                     </div>
                     <div class="control-group">
                         <label class="control-label">Rotation Y (Turn)</label>
                         <div class="control-row">
                             <input type="range" id="rotation-3d-y" min="-45" max="45" value="0">
-                            <span class="range-value" id="rotation-3d-y-value">0°</span>
+                            <div class="trailing-input-symbol-wrapper">
+                                <input type="text" class="range-value" id="rotation-3d-y-value" min="-45" max="45" value="0"></input>
+                                <span class="trailing-input-symbol">°</span>
+                            </div>
                         </div>
                     </div>
                     <div class="control-group">
                         <label class="control-label">Rotation Z (Roll)</label>
                         <div class="control-row">
                             <input type="range" id="rotation-3d-z" min="-45" max="45" value="0">
-                            <span class="range-value" id="rotation-3d-z-value">0°</span>
+                            <div class="trailing-input-symbol-wrapper">
+                                <input type="text" class="range-value" id="rotation-3d-z-value" min="-45" max="45" value="0"></input>
+                                <span class="trailing-input-symbol">°</span>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -633,7 +654,10 @@
                     <label class="control-label">Screenshot Scale</label>
                     <div class="control-row">
                         <input type="range" id="screenshot-scale" min="30" max="100" value="70">
-                        <span class="range-value" id="screenshot-scale-value">70%</span>
+                        <div class="trailing-input-symbol-wrapper">
+                            <input type="text" class="range-value" id="screenshot-scale-value" min="30" max="100" value="70"></input>
+                            <span class="trailing-input-symbol">%</span>
+                        </div>
                     </div>
                 </div>
 
@@ -641,7 +665,10 @@
                     <label class="control-label">Vertical Position</label>
                     <div class="control-row">
                         <input type="range" id="screenshot-y" min="-80" max="180" value="55">
-                        <span class="range-value" id="screenshot-y-value">55%</span>
+                        <div class="trailing-input-symbol-wrapper">
+                            <input type="text" class="range-value" id="screenshot-y-value" min="-80" max="180" value="55"></input>
+                            <span class="trailing-input-symbol">%</span>
+                        </div>
                     </div>
                 </div>
 
@@ -649,7 +676,10 @@
                     <label class="control-label">Horizontal Position</label>
                     <div class="control-row">
                         <input type="range" id="screenshot-x" min="-80" max="180" value="50">
-                        <span class="range-value" id="screenshot-x-value">50%</span>
+                        <div class="trailing-input-symbol-wrapper">
+                            <input type="text" class="range-value" id="screenshot-x-value" min="-80" max="180" value="50"></input>
+                            <span class="trailing-input-symbol">%</span>
+                        </div>
                     </div>
                 </div>
 
@@ -665,7 +695,10 @@
                         <label class="control-label">Corner Radius</label>
                         <div class="control-row">
                             <input type="range" id="corner-radius" min="0" max="100" value="24">
-                            <span class="range-value" id="corner-radius-value">24px</span>
+                            <div class="trailing-input-symbol-wrapper">
+                                <input type="text" class="range-value" id="corner-radius-value" min="0" max="100" value="24"></input>
+                                <span class="trailing-input-symbol">px</span>
+                            </div>
                         </div>
                     </div>
 
@@ -673,7 +706,10 @@
                         <label class="control-label">Tilt / Rotation</label>
                         <div class="control-row">
                             <input type="range" id="screenshot-rotation" min="-45" max="45" value="0">
-                            <span class="range-value" id="screenshot-rotation-value">0°</span>
+                            <div class="trailing-input-symbol-wrapper">
+                                <input type="text" class="range-value" id="screenshot-rotation-value" min="-45" max="45" value="0"></input>
+                                <span class="trailing-input-symbol">°</span>
+                            </div>
                         </div>
                     </div>
 
@@ -703,28 +739,40 @@
                         <label class="control-label">Blur</label>
                         <div class="control-row">
                             <input type="range" id="shadow-blur" min="0" max="100" value="40">
-                            <span class="range-value" id="shadow-blur-value">40px</span>
+                            <div class="trailing-input-symbol-wrapper">
+                                <input type="text" class="range-value" id="shadow-blur-value" min="0" max="100" value="40"></input>
+                                <span class="trailing-input-symbol">px</span>
+                            </div>
                         </div>
                     </div>
                     <div class="control-group">
                         <label class="control-label">Opacity</label>
                         <div class="control-row">
                             <input type="range" id="shadow-opacity" min="0" max="100" value="30">
-                            <span class="range-value" id="shadow-opacity-value">30%</span>
+                            <div class="trailing-input-symbol-wrapper">
+                                <input type="text" class="range-value" id="shadow-opacity-value" min="0" max="100" value="30"></input>
+                                <span class="trailing-input-symbol">%</span>
+                            </div>
                         </div>
                     </div>
                     <div class="control-group">
                         <label class="control-label">Offset Y</label>
                         <div class="control-row">
                             <input type="range" id="shadow-y" min="-50" max="100" value="20">
-                            <span class="range-value" id="shadow-y-value">20px</span>
+                            <div class="trailing-input-symbol-wrapper">
+                                <input type="text" class="range-value" id="shadow-y-value" min="-50" max="100" value="20"></input>
+                                <span class="trailing-input-symbol">px</span>
+                            </div>
                         </div>
                     </div>
                     <div class="control-group">
                         <label class="control-label">Offset X</label>
                         <div class="control-row">
                             <input type="range" id="shadow-x" min="-50" max="50" value="0">
-                            <span class="range-value" id="shadow-x-value">0px</span>
+                            <div class="trailing-input-symbol-wrapper">
+                                <input type="text" class="range-value" id="shadow-x-value" min="-50" max="50" value="0"></input>
+                                <span class="trailing-input-symbol">px</span>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -755,14 +803,20 @@
                         <label class="control-label">Border Width</label>
                         <div class="control-row">
                             <input type="range" id="frame-width" min="1" max="50" value="12">
-                            <span class="range-value" id="frame-width-value">12px</span>
+                            <div class="trailing-input-symbol-wrapper">
+                                <input type="text" class="range-value" id="frame-width-value" min="1" max="50" value="12"></input>
+                                <span class="trailing-input-symbol">px</span>
+                            </div>
                         </div>
                     </div>
                     <div class="control-group">
                         <label class="control-label">Border Opacity</label>
                         <div class="control-row">
                             <input type="range" id="frame-opacity" min="0" max="100" value="100">
-                            <span class="range-value" id="frame-opacity-value">100%</span>
+                            <div class="trailing-input-symbol-wrapper">
+                                <input type="text" class="range-value" id="frame-opacity-value" min="0" max="100" value="100"></input>
+                                <span class="trailing-input-symbol">%</span>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -885,7 +939,10 @@
                     <label class="control-label">Text Vertical Offset</label>
                     <div class="control-row">
                         <input type="range" id="text-offset-y" min="0" max="100" value="12">
-                        <span class="range-value" id="text-offset-y-value">12%</span>
+                        <div class="trailing-input-symbol-wrapper">
+                            <input type="text" class="range-value" id="text-offset-y-value" min="0" max="100" value="12"></input>
+                            <span class="trailing-input-symbol">%</span>
+                        </div>
                     </div>
                 </div>
 
@@ -893,7 +950,10 @@
                     <label class="control-label">Line Height</label>
                     <div class="control-row">
                         <input type="range" id="line-height" min="80" max="250" value="110">
-                        <span class="range-value" id="line-height-value">110%</span>
+                        <div class="trailing-input-symbol-wrapper">
+                            <input type="text" class="range-value" id="line-height-value" min="80" max="250" value="110"></input>
+                            <span class="trailing-input-symbol">%</span>
+                        </div>
                     </div>
                 </div>
                 </div><!-- end headline-options -->
@@ -991,7 +1051,10 @@
                     <label class="control-label">Subheadline Opacity</label>
                     <div class="control-row">
                         <input type="range" id="subheadline-opacity" min="0" max="100" value="70">
-                        <span class="range-value" id="subheadline-opacity-value">70%</span>
+                        <div class="trailing-input-symbol-wrapper">
+                            <input type="text" class="range-value" id="subheadline-opacity-value" min="0" max="100" value="70"></input>
+                            <span class="trailing-input-symbol">%</span>
+                        </div>
                     </div>
                 </div>
                 </div><!-- end subheadline-options -->
@@ -1091,7 +1154,10 @@
                         <label class="control-label">Position X</label>
                         <div class="control-row">
                             <input type="range" id="element-x" min="0" max="100" value="50">
-                            <span class="range-value" id="element-x-value">50%</span>
+                            <div class="trailing-input-symbol-wrapper">
+                                <input type="text" class="range-value" id="element-x-value" min="0" max="100" value="50"></input>
+                                <span class="trailing-input-symbol">%</span>
+                            </div>
                         </div>
                     </div>
 
@@ -1099,7 +1165,10 @@
                         <label class="control-label">Position Y</label>
                         <div class="control-row">
                             <input type="range" id="element-y" min="0" max="100" value="50">
-                            <span class="range-value" id="element-y-value">50%</span>
+                            <div class="trailing-input-symbol-wrapper">
+                                <input type="text" class="range-value" id="element-y-value" min="0" max="100" value="50"></input>
+                                <span class="trailing-input-symbol">%</span>
+                            </div>
                         </div>
                     </div>
 
@@ -1107,7 +1176,10 @@
                         <label class="control-label">Size</label>
                         <div class="control-row">
                             <input type="range" id="element-width" min="2" max="100" value="20">
-                            <span class="range-value" id="element-width-value">20%</span>
+                            <div class="trailing-input-symbol-wrapper">
+                                <input type="text" class="range-value" id="element-width-value" min="2" max="100" value="20"></input>
+                                <span class="trailing-input-symbol">%</span>
+                            </div>
                         </div>
                     </div>
 
@@ -1115,7 +1187,10 @@
                         <label class="control-label">Rotation</label>
                         <div class="control-row">
                             <input type="range" id="element-rotation" min="-180" max="180" value="0">
-                            <span class="range-value" id="element-rotation-value">0°</span>
+                            <div class="trailing-input-symbol-wrapper">
+                                <input type="text" class="range-value" id="element-rotation-value" min="-180" max="180" value="0"></input>
+                                <span class="trailing-input-symbol">°</span>
+                            </div>
                         </div>
                     </div>
 
@@ -1123,7 +1198,10 @@
                         <label class="control-label">Opacity</label>
                         <div class="control-row">
                             <input type="range" id="element-opacity" min="0" max="100" value="100">
-                            <span class="range-value" id="element-opacity-value">100%</span>
+                            <div class="trailing-input-symbol-wrapper">
+                                <input type="text" class="range-value" id="element-opacity-value" min="0" max="100" value="100"></input>
+                                <span class="trailing-input-symbol">%</span>
+                            </div>
                         </div>
                     </div>
 
@@ -1141,7 +1219,10 @@
                             <label class="control-label">Stroke Width</label>
                             <div class="control-row">
                                 <input type="range" id="element-icon-stroke-width" min="0.5" max="4" step="0.25" value="2">
-                                <span class="range-value" id="element-icon-stroke-width-value">2</span>
+                                <div class="trailing-input-symbol-wrapper">
+                                    <input type="text" class="range-value" id="element-icon-stroke-width-value" min="0.5" max="4" step="0.25" value="2"></input>
+                                    <span class="trailing-input-symbol"></span>
+                                </div>
                             </div>
                         </div>
                         <div class="divider"></div>
@@ -1168,28 +1249,40 @@
                                 <label class="control-label">Blur</label>
                                 <div class="control-row">
                                     <input type="range" id="element-icon-shadow-blur" min="0" max="100" value="20">
-                                    <span class="range-value" id="element-icon-shadow-blur-value">20px</span>
+                                    <div class="trailing-input-symbol-wrapper">
+                                        <input type="text" class="range-value" id="element-icon-shadow-blur-value" min="0" max="100" value="20"></input>
+                                        <span class="trailing-input-symbol">px</span>
+                                    </div>
                                 </div>
                             </div>
                             <div class="control-group">
                                 <label class="control-label">Opacity</label>
                                 <div class="control-row">
                                     <input type="range" id="element-icon-shadow-opacity" min="0" max="100" value="40">
-                                    <span class="range-value" id="element-icon-shadow-opacity-value">40%</span>
+                                    <div class="trailing-input-symbol-wrapper">
+                                        <input type="text" class="range-value" id="element-icon-shadow-opacity-value" min="0" max="100" value="40"></input>
+                                        <span class="trailing-input-symbol">%</span>
+                                    </div>
                                 </div>
                             </div>
                             <div class="control-group">
                                 <label class="control-label">Offset X</label>
                                 <div class="control-row">
                                     <input type="range" id="element-icon-shadow-x" min="-50" max="50" value="0">
-                                    <span class="range-value" id="element-icon-shadow-x-value">0px</span>
+                                    <div class="trailing-input-symbol-wrapper">
+                                        <input type="text" class="range-value" id="element-icon-shadow-x-value" min="-50" max="50" value="0"></input>
+                                        <span class="trailing-input-symbol">px</span>
+                                    </div>
                                 </div>
                             </div>
                             <div class="control-group">
                                 <label class="control-label">Offset Y</label>
                                 <div class="control-row">
                                     <input type="range" id="element-icon-shadow-y" min="-50" max="50" value="10">
-                                    <span class="range-value" id="element-icon-shadow-y-value">10px</span>
+                                    <div class="trailing-input-symbol-wrapper">
+                                        <input type="text" class="range-value" id="element-icon-shadow-y-value" min="-50" max="50" value="10"></input>
+                                        <span class="trailing-input-symbol">px</span>
+                                    </div>
                                 </div>
                             </div>
                         </div>
@@ -1288,7 +1381,10 @@
                                 <label class="control-label">Frame Scale</label>
                                 <div class="control-row">
                                     <input type="range" id="element-frame-scale" min="50" max="200" value="100">
-                                    <span class="range-value" id="element-frame-scale-value">100%</span>
+                                    <div class="trailing-input-symbol-wrapper">
+                                        <input type="text" class="range-value" id="element-frame-scale-value" min="50" max="200" value="100"></input>
+                                        <span class="trailing-input-symbol">%</span>
+                                    </div>
                                 </div>
                             </div>
                         </div>
@@ -1324,28 +1420,40 @@
                         <label class="control-label">Crop X</label>
                         <div class="control-row">
                             <input type="range" id="popout-crop-x" min="0" max="90" value="25" step="1">
-                            <span class="range-value" id="popout-crop-x-value">25%</span>
+                            <div class="trailing-input-symbol-wrapper">
+                                <input type="text" class="range-value" id="popout-crop-x-value" min="0" max="90" value="25" step="1"></input>
+                                <span class="trailing-input-symbol">%</span>
+                            </div>
                         </div>
                     </div>
                     <div class="control-group">
                         <label class="control-label">Crop Y</label>
                         <div class="control-row">
                             <input type="range" id="popout-crop-y" min="0" max="90" value="25" step="1">
-                            <span class="range-value" id="popout-crop-y-value">25%</span>
+                            <div class="trailing-input-symbol-wrapper">
+                                <input type="text" class="range-value" id="popout-crop-y-value" min="0" max="90" value="25" step="1"></input>
+                                <span class="trailing-input-symbol">%</span>
+                            </div>
                         </div>
                     </div>
                     <div class="control-group">
                         <label class="control-label">Crop Width</label>
                         <div class="control-row">
                             <input type="range" id="popout-crop-width" min="5" max="100" value="30" step="1">
-                            <span class="range-value" id="popout-crop-width-value">30%</span>
+                            <div class="trailing-input-symbol-wrapper">
+                                <input type="text" class="range-value" id="popout-crop-width-value" min="5" max="100" value="30" step="1"></input>
+                                <span class="trailing-input-symbol">%</span>
+                            </div>
                         </div>
                     </div>
                     <div class="control-group">
                         <label class="control-label">Crop Height</label>
                         <div class="control-row">
                             <input type="range" id="popout-crop-height" min="5" max="100" value="30" step="1">
-                            <span class="range-value" id="popout-crop-height-value">30%</span>
+                            <div class="trailing-input-symbol-wrapper">
+                                <input type="text" class="range-value" id="popout-crop-height-value" min="5" max="100" value="30" step="1"></input>
+                                <span class="trailing-input-symbol">%</span>
+                            </div>
                         </div>
                     </div>
 
@@ -1356,42 +1464,60 @@
                         <label class="control-label">Position X</label>
                         <div class="control-row">
                             <input type="range" id="popout-x" min="0" max="100" value="70">
-                            <span class="range-value" id="popout-x-value">70%</span>
+                            <div class="trailing-input-symbol-wrapper">
+                                <input type="text" class="range-value" id="popout-x-value" min="0" max="100" value="70"></input>
+                                <span class="trailing-input-symbol">%</span>
+                            </div>
                         </div>
                     </div>
                     <div class="control-group">
                         <label class="control-label">Position Y</label>
                         <div class="control-row">
                             <input type="range" id="popout-y" min="0" max="100" value="30">
-                            <span class="range-value" id="popout-y-value">30%</span>
+                            <div class="trailing-input-symbol-wrapper">
+                                <input type="text" class="range-value" id="popout-y-value" min="0" max="100" value="30"></input>
+                                <span class="trailing-input-symbol">%</span>
+                            </div>
                         </div>
                     </div>
                     <div class="control-group">
                         <label class="control-label">Size</label>
                         <div class="control-row">
                             <input type="range" id="popout-width" min="5" max="130" value="30">
-                            <span class="range-value" id="popout-width-value">30%</span>
+                            <div class="trailing-input-symbol-wrapper">
+                                <input type="text" class="range-value" id="popout-width-value" min="5" max="130" value="30"></input>
+                                <span class="trailing-input-symbol">%</span>
+                            </div>
                         </div>
                     </div>
                     <div class="control-group">
                         <label class="control-label">Rotation</label>
                         <div class="control-row">
                             <input type="range" id="popout-rotation" min="-180" max="180" value="0">
-                            <span class="range-value" id="popout-rotation-value">0°</span>
+                            <div class="trailing-input-symbol-wrapper">
+                                <input type="text" class="range-value" id="popout-rotation-value" min="-180" max="180" value="0"></input>
+                                <span class="trailing-input-symbol">°</span>
+                            </div>
                         </div>
                     </div>
                     <div class="control-group">
                         <label class="control-label">Opacity</label>
                         <div class="control-row">
                             <input type="range" id="popout-opacity" min="0" max="100" value="100">
-                            <span class="range-value" id="popout-opacity-value">100%</span>
+                            <div class="trailing-input-symbol-wrapper">
+                                <input type="text" class="range-value" id="popout-opacity-value" min="0" max="100" value="100"></input>
+                                <span class="trailing-input-symbol">%</span>
+                            </div>
                         </div>
                     </div>
                     <div class="control-group">
                         <label class="control-label">Corner Radius</label>
                         <div class="control-row">
                             <input type="range" id="popout-corner-radius" min="0" max="50" value="12">
-                            <span class="range-value" id="popout-corner-radius-value">12px</span>
+                            <div class="trailing-input-symbol-wrapper">
+                                <input type="text" class="range-value" id="popout-corner-radius-value" min="0" max="50" value="12"></input>
+                                <span class="trailing-input-symbol">px</span>
+                            </div>
                         </div>
                     </div>
 
@@ -1413,28 +1539,40 @@
                             <label class="control-label">Blur</label>
                             <div class="control-row">
                                 <input type="range" id="popout-shadow-blur" min="0" max="100" value="30">
-                                <span class="range-value" id="popout-shadow-blur-value">30px</span>
+                                <div class="trailing-input-symbol-wrapper">
+                                    <input type="text" class="range-value" id="popout-shadow-blur-value" min="0" max="100" value="30"></input>
+                                    <span class="trailing-input-symbol">px</span>
+                                </div>
                             </div>
                         </div>
                         <div class="control-group">
                             <label class="control-label">Opacity</label>
                             <div class="control-row">
                                 <input type="range" id="popout-shadow-opacity" min="0" max="100" value="40">
-                                <span class="range-value" id="popout-shadow-opacity-value">40%</span>
+                                <div class="trailing-input-symbol-wrapper">
+                                    <input type="text" class="range-value" id="popout-shadow-opacity-value" min="0" max="100" value="40"></input>
+                                    <span class="trailing-input-symbol">%</span>
+                                </div>
                             </div>
                         </div>
                         <div class="control-group">
                             <label class="control-label">Offset X</label>
                             <div class="control-row">
                                 <input type="range" id="popout-shadow-x" min="-50" max="50" value="0">
-                                <span class="range-value" id="popout-shadow-x-value">0px</span>
+                                <div class="trailing-input-symbol-wrapper">
+                                    <input type="text" class="range-value" id="popout-shadow-x-value" min="-50" max="50" value="0"></input>
+                                    <span class="trailing-input-symbol">px</span>
+                                </div>
                             </div>
                         </div>
                         <div class="control-group">
                             <label class="control-label">Offset Y</label>
                             <div class="control-row">
                                 <input type="range" id="popout-shadow-y" min="-50" max="50" value="15">
-                                <span class="range-value" id="popout-shadow-y-value">15px</span>
+                                <div class="trailing-input-symbol-wrapper">
+                                    <input type="text" class="range-value" id="popout-shadow-y-value" min="-50" max="50" value="15"></input>
+                                    <span class="trailing-input-symbol">px</span>
+                                </div>
                             </div>
                         </div>
                     </div>
@@ -1457,14 +1595,20 @@
                             <label class="control-label">Width</label>
                             <div class="control-row">
                                 <input type="range" id="popout-border-width" min="0" max="20" value="3">
-                                <span class="range-value" id="popout-border-width-value">3px</span>
+                                <div class="trailing-input-symbol-wrapper">
+                                    <input type="text" class="range-value" id="popout-border-width-value" min="0" max="20" value="3"></input>
+                                    <span class="trailing-input-symbol">px</span>
+                                </div>
                             </div>
                         </div>
                         <div class="control-group">
                             <label class="control-label">Opacity</label>
                             <div class="control-row">
                                 <input type="range" id="popout-border-opacity" min="0" max="100" value="100">
-                                <span class="range-value" id="popout-border-opacity-value">100%</span>
+                                <div class="trailing-input-symbol-wrapper">
+                                    <input type="text" class="range-value" id="popout-border-opacity-value" min="0" max="100" value="100"></input>
+                                    <span class="trailing-input-symbol">%</span>
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/index.html
+++ b/index.html
@@ -422,7 +422,8 @@
                         <label class="control-label">Gradient Direction</label>
                         <div class="control-row">
                             <input type="range" id="gradient-angle" min="0" max="360" value="135">
-                            <span class="range-value" id="gradient-angle-value">135°</span>
+                            <div class="trailing-input-symbol-wrapper"><input type="text" class="range-value" id="gradient-angle-value"></input><span class="trailing-input-symbol">°</span></div>
+
                         </div>
                     </div>
 

--- a/styles.css
+++ b/styles.css
@@ -580,8 +580,10 @@ html.tauri-app .right-sidebar {
 
 .trailing-input-symbol{
     position: absolute;
-    top: 8px;
+    top: 50%;
+    transform: translateY(-50%);
     right: 6px;
+    font-size: 0.75rem;
 }
 
 .slider-reset-btn {
@@ -615,7 +617,7 @@ input[type="number"],
 select,
 textarea {
     width: 100%;
-    padding: 10px 12px;
+    padding: 10px 20px 10px 12px;
     background: var(--bg-tertiary);
     border: 1px solid var(--border-color);
     border-radius: 8px;

--- a/styles.css
+++ b/styles.css
@@ -575,7 +575,7 @@ html.tauri-app .right-sidebar {
     width: 10ch;
     text-align: right;
     font-size: 13px;
-    color: #000;
+    color: var(--text-primary);
 }
 
 .trailing-input-symbol{
@@ -601,6 +601,10 @@ html.tauri-app .right-sidebar {
     display: flex;
     align-items: center;
     justify-content: center;
+}
+
+.slider-reset-btn svg{
+    stroke: red;
 }
 
 .control-row:hover .slider-reset-btn {

--- a/styles.css
+++ b/styles.css
@@ -567,9 +567,21 @@ html.tauri-app .right-sidebar {
     flex: 1;
 }
 
+.trailing-input-symbol-wrapper{
+    position: relative;
+}
+
 .control-row .range-value {
-    min-width: 45px;
+    width: 10ch;
     text-align: right;
+    font-size: 13px;
+    color: #000;
+}
+
+.trailing-input-symbol{
+    position: absolute;
+    top: 8px;
+    right: 6px;
 }
 
 .slider-reset-btn {
@@ -649,7 +661,7 @@ input[type="range"]::-webkit-slider-thumb {
 }
 
 .range-value {
-    min-width: 40px;
+    width: 10ch;
     text-align: right;
     font-size: 13px;
     color: var(--text-secondary);


### PR DESCRIPTION
Replaces range slider value texts with input fields.
Changing range slider updates input field value and vice versa.
Removed unit suffixes in values and inserted them as a span element.

Reason: Range slider manipulation is cumbersome when trying to set an exact value (e.g. wanting to set 75% but slider jumps from 74% to 76%).