### PR TITLE
Fix image background on multiple screenshots and add text shadow

### DIFF
--- a/app.js
+++ b/app.js
@@ -90,7 +90,15 @@ const state = {
             subheadlineUnderline: false,
             subheadlineStrikethrough: false,
             subheadlineColor: '#ffffff',
-            subheadlineOpacity: 70
+            subheadlineOpacity: 70,
+            shadow: {
+                enabled: false,
+                color: '#000000',
+                blur: 10,
+                opacity: 50,
+                x: 0,
+                y: 4
+            }
         },
         elements: [],
         popouts: []
@@ -583,6 +591,10 @@ function setCurrentScreenshotAsDefault() {
     const screenshot = getCurrentScreenshot();
     if (screenshot) {
         state.defaults.background = JSON.parse(JSON.stringify(screenshot.background));
+        // Preserve Image object (not JSON serializable)
+        if (screenshot.background.image) {
+            state.defaults.background.image = screenshot.background.image;
+        }
         state.defaults.screenshot = JSON.parse(JSON.stringify(screenshot.screenshot));
         state.defaults.text = JSON.parse(JSON.stringify(screenshot.text));
     }
@@ -1510,7 +1522,7 @@ function saveState() {
             name: s.name,
             deviceType: s.deviceType,
             localizedImages: localizedImages,
-            background: s.background,
+            background: { ...s.background, image: undefined },
             screenshot: s.screenshot,
             text: s.text,
             elements: (s.elements || []).map(el => ({
@@ -1568,6 +1580,18 @@ function migrate3DPosition(screenshotSettings) {
 
     screenshotSettings.x = Math.max(0, Math.min(100, 50 + (oldX - 50) * xFactor));
     screenshotSettings.y = Math.max(0, Math.min(100, 50 + (oldY - 50) * yFactor));
+}
+
+// Reconstruct background Image object from stored imageSrc data URL
+function reconstructBackgroundImage(background) {
+    if (background && background.imageSrc && !background.image) {
+        const img = new Image();
+        img.onload = () => {
+            background.image = img;
+            updateCanvas();
+        };
+        img.src = background.imageSrc;
+    }
 }
 
 // Reconstruct Image objects for graphic/icon elements from saved data
@@ -1670,6 +1694,7 @@ function loadState() {
                                     popouts: s.popouts || [],
                                     overrides: s.overrides || {}
                                 };
+                                reconstructBackgroundImage(state.screenshots[index].background);
                                 loadedCount++;
                                 checkAllLoaded();
                             } else if (hasLocalizedImages) {
@@ -1709,6 +1734,7 @@ function loadState() {
                                                     popouts: s.popouts || [],
                                                     overrides: s.overrides || {}
                                                 };
+                                                reconstructBackgroundImage(state.screenshots[index].background);
                                                 loadedCount++;
                                                 checkAllLoaded();
                                             }
@@ -1754,6 +1780,7 @@ function loadState() {
                                         popouts: s.popouts || [],
                                         overrides: s.overrides || {}
                                     };
+                                    reconstructBackgroundImage(state.screenshots[index].background);
                                     loadedCount++;
                                     checkAllLoaded();
                                 };
@@ -1927,7 +1954,15 @@ function resetStateToDefaults() {
             subheadlineUnderline: false,
             subheadlineStrikethrough: false,
             subheadlineColor: '#ffffff',
-            subheadlineOpacity: 70
+            subheadlineOpacity: 70,
+            shadow: {
+                enabled: false,
+                color: '#000000',
+                blur: 10,
+                opacity: 50,
+                x: 0,
+                y: 4
+            }
         }
     };
 }
@@ -2175,6 +2210,23 @@ function syncUIWithState() {
     document.getElementById('solid-color-hex').value = bg.solid;
 
     // Image background
+    const bgImagePreview = document.getElementById('bg-image-preview');
+    if (bg.imageSrc) {
+        bgImagePreview.src = bg.imageSrc;
+        bgImagePreview.style.display = 'block';
+        // Reconstruct Image object if missing (e.g. after deep copy)
+        if (!bg.image) {
+            const img = new Image();
+            img.onload = () => {
+                setBackground('image', img);
+                updateCanvas();
+            };
+            img.src = bg.imageSrc;
+        }
+    } else {
+        bgImagePreview.src = '';
+        bgImagePreview.style.display = 'none';
+    }
     document.getElementById('bg-image-fit').value = bg.imageFit;
     document.getElementById('bg-blur').value = bg.imageBlur;
     document.getElementById('bg-blur-value').textContent = formatValue(bg.imageBlur) + 'px';
@@ -2272,6 +2324,23 @@ function syncUIWithState() {
     const subheadlineEnabled = txt.subheadlineEnabled || false;
     document.getElementById('headline-toggle').classList.toggle('active', headlineEnabled);
     document.getElementById('subheadline-toggle').classList.toggle('active', subheadlineEnabled);
+
+    // Text shadow
+    const textShadow = txt.shadow || { enabled: false, color: '#000000', blur: 10, opacity: 50, x: 0, y: 4 };
+    document.getElementById('text-shadow-toggle').classList.toggle('active', textShadow.enabled);
+    const textShadowRow = document.getElementById('text-shadow-toggle')?.closest('.toggle-row');
+    if (textShadowRow) textShadowRow.classList.toggle('collapsed', !textShadow.enabled);
+    document.getElementById('text-shadow-options').style.display = textShadow.enabled ? '' : 'none';
+    document.getElementById('text-shadow-color').value = textShadow.color;
+    document.getElementById('text-shadow-color-hex').value = textShadow.color;
+    document.getElementById('text-shadow-blur').value = textShadow.blur;
+    document.getElementById('text-shadow-blur-value').textContent = formatValue(textShadow.blur) + 'px';
+    document.getElementById('text-shadow-opacity').value = textShadow.opacity;
+    document.getElementById('text-shadow-opacity-value').textContent = formatValue(textShadow.opacity) + '%';
+    document.getElementById('text-shadow-x').value = textShadow.x;
+    document.getElementById('text-shadow-x-value').textContent = formatValue(textShadow.x) + 'px';
+    document.getElementById('text-shadow-y').value = textShadow.y;
+    document.getElementById('text-shadow-y-value').textContent = formatValue(textShadow.y) + 'px';
 
     // Language UIs
     updateHeadlineLanguageUI();
@@ -4210,6 +4279,7 @@ function setupEventListeners() {
                 const img = new Image();
                 img.onload = () => {
                     setBackground('image', img);
+                    setBackground('imageSrc', event.target.result);
                     document.getElementById('bg-image-preview').src = event.target.result;
                     document.getElementById('bg-image-preview').style.display = 'block';
                     updateCanvas();
@@ -4218,6 +4288,8 @@ function setupEventListeners() {
             };
             reader.readAsDataURL(e.target.files[0]);
         }
+        // Reset so the same file can be re-selected
+        e.target.value = '';
     });
 
     document.getElementById('bg-image-fit').addEventListener('change', (e) => {
@@ -4543,6 +4615,67 @@ function setupEventListeners() {
             btn.classList.toggle('active', newValue);
             updateCanvas();
         });
+    });
+
+    // Text shadow toggle
+    document.getElementById('text-shadow-toggle').addEventListener('click', function () {
+        this.classList.toggle('active');
+        const enabled = this.classList.contains('active');
+        const text = getTextSettings();
+        if (!text.shadow) text.shadow = { enabled: false, color: '#000000', blur: 10, opacity: 50, x: 0, y: 4 };
+        text.shadow.enabled = enabled;
+        const row = this.closest('.toggle-row');
+        if (row) row.classList.toggle('collapsed', !enabled);
+        document.getElementById('text-shadow-options').style.display = enabled ? '' : 'none';
+        updateCanvas();
+    });
+
+    document.getElementById('text-shadow-color').addEventListener('input', (e) => {
+        const text = getTextSettings();
+        if (text.shadow) text.shadow.color = e.target.value;
+        document.getElementById('text-shadow-color-hex').value = e.target.value;
+        updateCanvas();
+    });
+
+    document.getElementById('text-shadow-color-hex').addEventListener('change', (e) => {
+        if (/^#[0-9a-fA-F]{6}$/.test(e.target.value)) {
+            const text = getTextSettings();
+            if (text.shadow) text.shadow.color = e.target.value;
+            document.getElementById('text-shadow-color').value = e.target.value;
+            updateCanvas();
+        }
+    });
+
+    document.getElementById('text-shadow-blur').addEventListener('input', (e) => {
+        const value = parseInt(e.target.value) || 0;
+        const text = getTextSettings();
+        if (text.shadow) text.shadow.blur = value;
+        document.getElementById('text-shadow-blur-value').textContent = formatValue(value) + 'px';
+        updateCanvas();
+    });
+
+    document.getElementById('text-shadow-opacity').addEventListener('input', (e) => {
+        const value = parseInt(e.target.value) || 0;
+        const text = getTextSettings();
+        if (text.shadow) text.shadow.opacity = value;
+        document.getElementById('text-shadow-opacity-value').textContent = formatValue(value) + '%';
+        updateCanvas();
+    });
+
+    document.getElementById('text-shadow-x').addEventListener('input', (e) => {
+        const value = parseInt(e.target.value) || 0;
+        const text = getTextSettings();
+        if (text.shadow) text.shadow.x = value;
+        document.getElementById('text-shadow-x-value').textContent = formatValue(value) + 'px';
+        updateCanvas();
+    });
+
+    document.getElementById('text-shadow-y').addEventListener('input', (e) => {
+        const value = parseInt(e.target.value) || 0;
+        const text = getTextSettings();
+        if (text.shadow) text.shadow.y = value;
+        document.getElementById('text-shadow-y-value').textContent = formatValue(value) + 'px';
+        updateCanvas();
     });
 
     // Export buttons
@@ -7249,6 +7382,18 @@ function drawTextToContext(context, dims, txt) {
     context.textAlign = 'center';
     context.textBaseline = layoutSettings.position === 'top' ? 'top' : 'bottom';
 
+    // Apply text shadow if enabled
+    if (txt.shadow && txt.shadow.enabled) {
+        const hex = txt.shadow.color || '#000000';
+        const r = parseInt(hex.slice(1, 3), 16);
+        const g = parseInt(hex.slice(3, 5), 16);
+        const b = parseInt(hex.slice(5, 7), 16);
+        context.shadowColor = `rgba(${r},${g},${b},${(txt.shadow.opacity || 0) / 100})`;
+        context.shadowBlur = txt.shadow.blur || 0;
+        context.shadowOffsetX = txt.shadow.x || 0;
+        context.shadowOffsetY = txt.shadow.y || 0;
+    }
+
     let currentY = textY;
 
     // Draw headline
@@ -7351,6 +7496,14 @@ function drawTextToContext(context, dims, txt) {
         if (layoutSettings.position === 'bottom') {
             context.textBaseline = 'bottom';
         }
+    }
+
+    // Clear text shadow
+    if (txt.shadow && txt.shadow.enabled) {
+        context.shadowColor = 'transparent';
+        context.shadowBlur = 0;
+        context.shadowOffsetX = 0;
+        context.shadowOffsetY = 0;
     }
 }
 
@@ -7844,6 +7997,18 @@ function drawText() {
     ctx.textAlign = 'center';
     ctx.textBaseline = layoutSettings.position === 'top' ? 'top' : 'bottom';
 
+    // Apply text shadow if enabled
+    if (text.shadow && text.shadow.enabled) {
+        const hex = text.shadow.color || '#000000';
+        const r = parseInt(hex.slice(1, 3), 16);
+        const g = parseInt(hex.slice(3, 5), 16);
+        const b = parseInt(hex.slice(5, 7), 16);
+        ctx.shadowColor = `rgba(${r},${g},${b},${(text.shadow.opacity || 0) / 100})`;
+        ctx.shadowBlur = text.shadow.blur || 0;
+        ctx.shadowOffsetX = text.shadow.x || 0;
+        ctx.shadowOffsetY = text.shadow.y || 0;
+    }
+
     let currentY = textY;
 
     // Draw headline
@@ -7946,6 +8111,14 @@ function drawText() {
         if (layoutSettings.position === 'bottom') {
             ctx.textBaseline = 'bottom';
         }
+    }
+
+    // Clear text shadow
+    if (text.shadow && text.shadow.enabled) {
+        ctx.shadowColor = 'transparent';
+        ctx.shadowBlur = 0;
+        ctx.shadowOffsetX = 0;
+        ctx.shadowOffsetY = 0;
     }
 }
 

--- a/index.html
+++ b/index.html
@@ -994,6 +994,58 @@
                     </div>
                 </div>
                 </div><!-- end subheadline-options -->
+
+                <div class="divider"></div>
+
+                <div class="control-group">
+                    <div class="toggle-row collapsible collapsed" data-target="text-shadow-options">
+                        <span class="toggle-label">
+                            <svg class="chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                <polyline points="6 9 12 15 18 9"/>
+                            </svg>
+                            Text Shadow
+                        </span>
+                        <div class="toggle" id="text-shadow-toggle"></div>
+                    </div>
+                </div>
+
+                <div id="text-shadow-options" style="display: none;">
+                    <div class="control-group">
+                        <label class="control-label">Shadow Color</label>
+                        <div class="color-input-wrapper">
+                            <input type="color" id="text-shadow-color" value="#000000">
+                            <input type="text" id="text-shadow-color-hex" value="#000000">
+                        </div>
+                    </div>
+                    <div class="control-group">
+                        <label class="control-label">Blur</label>
+                        <div class="control-row">
+                            <input type="range" id="text-shadow-blur" min="0" max="50" value="10">
+                            <span class="range-value" id="text-shadow-blur-value">10px</span>
+                        </div>
+                    </div>
+                    <div class="control-group">
+                        <label class="control-label">Opacity</label>
+                        <div class="control-row">
+                            <input type="range" id="text-shadow-opacity" min="0" max="100" value="50">
+                            <span class="range-value" id="text-shadow-opacity-value">50%</span>
+                        </div>
+                    </div>
+                    <div class="control-group">
+                        <label class="control-label">Distance X</label>
+                        <div class="control-row">
+                            <input type="range" id="text-shadow-x" min="-30" max="30" value="0">
+                            <span class="range-value" id="text-shadow-x-value">0px</span>
+                        </div>
+                    </div>
+                    <div class="control-group">
+                        <label class="control-label">Distance Y</label>
+                        <div class="control-row">
+                            <input type="range" id="text-shadow-y" min="-30" max="30" value="4">
+                            <span class="range-value" id="text-shadow-y-value">4px</span>
+                        </div>
+                    </div>
+                </div>
             </div>
 
             <!-- Elements Tab -->


### PR DESCRIPTION
## Summary
- **Bug fix:** Image backgrounds could only be applied to one screenshot. Switching to another screenshot and uploading or clicking the preview did nothing. Root cause was that the `Image` object was lost during deep copies (`JSON.parse/stringify`) and IndexedDB serialization. Fixed by storing the data URL as `imageSrc` alongside the object and reconstructing it after round-trips. Also reset the file input after upload so the same file can be re-selected.
- **New feature:** Added a Text Shadow section to the Text tab with controls for color, blur, opacity, and X/Y distance. Applies to both headline and subheadline. Saved per-screenshot. Follows the same collapsible toggle pattern as existing Shadow/Border sections.

## Test plan
- [ ] Upload an image background on screenshot 1, verify it renders
- [ ] Switch to screenshot 2, upload the same image — verify it applies
- [ ] Switch back to screenshot 1 — verify the image is still there
- [ ] Reload the page — verify image backgrounds persist across sessions
- [ ] Enable Text Shadow toggle, adjust color/blur/opacity/distance — verify shadow renders on canvas
- [ ] Verify text shadow works on both headline and subheadline
- [ ] Verify text shadow settings persist per-screenshot and across page reloads
- [ ] Export a screenshot with text shadow — verify it appears in the exported PNG