### PR TITLE
Add Export Format Switching / JPG Exporting

### DIFF
--- a/app.js
+++ b/app.js
@@ -8029,8 +8029,8 @@ async function exportCurrent() {
     updateCanvas();
 
     const link = document.createElement('a');
-    link.download = `screenshot-${state.selectedIndex + 1}.png`;
-    link.href = canvas.toDataURL('image/png');
+    link.download = `screenshot-${state.selectedIndex + 1}.jpg`;
+    link.href = canvas.toDataURL('image/jpeg', 1.0);
     link.click();
 }
 
@@ -8112,10 +8112,10 @@ async function exportAllForLanguage(lang) {
         await new Promise(resolve => setTimeout(resolve, 100));
 
         // Get canvas data as base64, strip the data URL prefix
-        const dataUrl = canvas.toDataURL('image/png');
-        const base64Data = dataUrl.replace(/^data:image\/png;base64,/, '');
+        const dataUrl = canvas.toDataURL('image/jpeg', 1.0);
+        const base64Data = dataUrl.replace(/^data:image\/jpeg;base64,/, '');
 
-        zip.file(`screenshot-${i + 1}.png`, base64Data, { base64: true });
+        zip.file(`screenshot-${i + 1}.jpg`, base64Data, { base64: true });
     }
 
     // Restore original settings
@@ -8184,11 +8184,11 @@ async function exportAllLanguages() {
             await new Promise(resolve => setTimeout(resolve, 100));
 
             // Get canvas data as base64, strip the data URL prefix
-            const dataUrl = canvas.toDataURL('image/png');
-            const base64Data = dataUrl.replace(/^data:image\/png;base64,/, '');
+            const dataUrl = canvas.toDataURL('image/jpeg', 1.0);
+            const base64Data = dataUrl.replace(/^data:image\/jpeg;base64,/, '');
 
             // Use language code as folder name
-            zip.file(`${lang}/screenshot-${i + 1}.png`, base64Data, { base64: true });
+            zip.file(`${lang}/screenshot-${i + 1}.jpg`, base64Data, { base64: true });
         }
     }
 

--- a/app.js
+++ b/app.js
@@ -8060,9 +8060,10 @@ async function exportCurrent() {
     // Ensure canvas is up-to-date (especially important for 3D mode)
     updateCanvas();
 
+    const { mime, ext, quality } = getExportEncoding();
     const link = document.createElement('a');
-    link.download = `screenshot-${state.selectedIndex + 1}.jpg`;
-    link.href = canvas.toDataURL('image/jpeg', 1.0);
+    link.download = `screenshot-${state.selectedIndex + 1}.${ext}`;
+    link.href = quality !== undefined ? canvas.toDataURL(mime, quality) : canvas.toDataURL(mime);
     link.click();
 }
 
@@ -8144,10 +8145,11 @@ async function exportAllForLanguage(lang) {
         await new Promise(resolve => setTimeout(resolve, 100));
 
         // Get canvas data as base64, strip the data URL prefix
-        const dataUrl = canvas.toDataURL('image/jpeg', 1.0);
-        const base64Data = dataUrl.replace(/^data:image\/jpeg;base64,/, '');
+        const { mime, ext, quality } = getExportEncoding();
+        const dataUrl = quality !== undefined ? canvas.toDataURL(mime, quality) : canvas.toDataURL(mime);
+        const base64Data = dataUrl.replace(/^data:[^;]+;base64,/, '');
 
-        zip.file(`screenshot-${i + 1}.jpg`, base64Data, { base64: true });
+        zip.file(`screenshot-${i + 1}.${ext}`, base64Data, { base64: true });
     }
 
     // Restore original settings

--- a/app.js
+++ b/app.js
@@ -8038,6 +8038,19 @@ function hexToRgba(hex, alpha) {
     return `rgba(${r}, ${g}, ${b}, ${alpha})`;
 }
 
+function getExportFormat() {
+    const stored = localStorage.getItem('exportFormat');
+    return stored === 'png' ? 'png' : 'jpeg';
+}
+
+function getExportEncoding() {
+    const format = getExportFormat();
+    if (format === 'png') {
+        return { mime: 'image/png', ext: 'png', quality: undefined };
+    }
+    return { mime: 'image/jpeg', ext: 'jpg', quality: 1.0 };
+}
+
 async function exportCurrent() {
     if (state.screenshots.length === 0) {
         await showAppAlert('Please upload a screenshot first', 'info');

--- a/app.js
+++ b/app.js
@@ -1254,7 +1254,7 @@ const deviceDimensions = {
 
 // DOM elements
 const canvas = document.getElementById('preview-canvas');
-const ctx = canvas.getContext('2d');
+const ctx = canvas.getContext('2d', { alpha: false });
 const canvasLeft = document.getElementById('preview-canvas-left');
 const ctxLeft = canvasLeft.getContext('2d');
 const canvasRight = document.getElementById('preview-canvas-right');

--- a/app.js
+++ b/app.js
@@ -3977,6 +3977,14 @@ function setupEventListeners() {
         });
     });
 
+    // Export format selector buttons
+    document.querySelectorAll('#export-format-selector button').forEach(btn => {
+        btn.addEventListener('click', () => {
+            document.querySelectorAll('#export-format-selector button').forEach(b => b.classList.remove('active'));
+            btn.classList.add('active');
+        });
+    });
+
     // Provider radio buttons
     document.querySelectorAll('input[name="ai-provider"]').forEach(radio => {
         radio.addEventListener('change', (e) => {
@@ -8184,11 +8192,12 @@ async function exportAllLanguages() {
             await new Promise(resolve => setTimeout(resolve, 100));
 
             // Get canvas data as base64, strip the data URL prefix
-            const dataUrl = canvas.toDataURL('image/jpeg', 1.0);
-            const base64Data = dataUrl.replace(/^data:image\/jpeg;base64,/, '');
+            const { mime, ext, quality } = getExportEncoding();
+            const dataUrl = quality !== undefined ? canvas.toDataURL(mime, quality) : canvas.toDataURL(mime);
+            const base64Data = dataUrl.replace(/^data:[^;]+;base64,/, '');
 
             // Use language code as folder name
-            zip.file(`${lang}/screenshot-${i + 1}.jpg`, base64Data, { base64: true });
+            zip.file(`${lang}/screenshot-${i + 1}.${ext}`, base64Data, { base64: true });
         }
     }
 

--- a/app.js
+++ b/app.js
@@ -5804,6 +5804,11 @@ function saveSettings() {
     localStorage.setItem('themePreference', themePreference);
     applyTheme(themePreference);
 
+    // Save export format preference
+    const activeFormatBtn = document.querySelector('#export-format-selector button.active');
+    const exportFormat = activeFormatBtn ? activeFormatBtn.dataset.format : 'jpeg';
+    localStorage.setItem('exportFormat', exportFormat);
+
     // Save selected provider
     const selectedProvider = document.querySelector('input[name="ai-provider"]:checked').value;
     localStorage.setItem('aiProvider', selectedProvider);

--- a/app.js
+++ b/app.js
@@ -5782,6 +5782,12 @@ function openSettingsModal() {
         btn.classList.toggle('active', btn.dataset.theme === savedTheme);
     });
 
+    // Load saved export format preference
+    const savedFormat = getExportFormat();
+    document.querySelectorAll('#export-format-selector button').forEach(btn => {
+        btn.classList.toggle('active', btn.dataset.format === savedFormat);
+    });
+
     document.getElementById('settings-modal').classList.add('visible');
 }
 

--- a/index.html
+++ b/index.html
@@ -1752,6 +1752,15 @@
                 </div>
             </div>
 
+            <div style="display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-bottom: 8px;">
+                <span style="font-size: 13px; color: var(--text-secondary); flex-shrink: 0;">Export format</span>
+                <div class="btn-group" id="export-format-selector" style="flex: 0 0 200px;">
+                    <button data-format="jpeg" class="active">JPEG</button>
+                    <button data-format="png">PNG</button>
+                </div>
+            </div>
+            <p class="settings-description" style="margin-bottom: 20px;">JPEG is recommended for App Store Connect uploads.</p>
+
             <div class="modal-buttons">
                 <button class="modal-btn modal-btn-cancel" id="settings-modal-cancel">Cancel</button>
                 <button class="modal-btn modal-btn-confirm" id="settings-modal-save">Save Settings</button>

--- a/index.html
+++ b/index.html
@@ -1759,7 +1759,6 @@
                     <button data-format="png">PNG</button>
                 </div>
             </div>
-            <p class="settings-description" style="margin-bottom: 20px;">JPEG is recommended for App Store Connect uploads.</p>
 
             <div class="modal-buttons">
                 <button class="modal-btn modal-btn-cancel" id="settings-modal-cancel">Cancel</button>


### PR DESCRIPTION
As mentioned in #24, exported PNGs can contain transparencies, which makes the exports not submittable in Appstore Connect. This PR aims to provide an option to export the pictures as JPGs, including a toggle in the settings:

<img width="1028" height="1546" alt="image" src="https://github.com/user-attachments/assets/ea3f8c1d-3e8e-4af1-a2fb-aead6b0a2d19" />
